### PR TITLE
Corrigir funcionalidade de text-to-speech

### DIFF
--- a/app.js
+++ b/app.js
@@ -371,6 +371,7 @@ function resetChat() {
 
 // Sistema de voz
 let voiceSystem = null;
+let ttsEnabled = true; // Controle para ativar/desativar TTS das respostas
 
 // Inicializar sistema de voz
 function initVoiceSystem() {
@@ -382,6 +383,7 @@ function initVoiceSystem() {
         // Configurar botões de voz
         const voiceBtn = document.getElementById('voice-btn');
         const voiceModeBtn = document.getElementById('voice-mode-btn');
+        const ttsToggleBtn = document.getElementById('tts-toggle-btn');
         const voiceIndicator = document.getElementById('voice-indicator');
         
         console.log('🔍 Elementos encontrados:', {
@@ -420,6 +422,20 @@ function initVoiceSystem() {
             console.error('❌ Botão de modo conversacional não encontrado!');
         }
         
+        // Configurar botão de TTS
+        if (ttsToggleBtn) {
+            ttsToggleBtn.addEventListener('click', () => {
+                ttsEnabled = !ttsEnabled;
+                ttsToggleBtn.classList.toggle('active', ttsEnabled);
+                ttsToggleBtn.textContent = ttsEnabled ? '🔊' : '🔇';
+                ttsToggleBtn.title = ttsEnabled ? 'Dublagem ativada' : 'Dublagem desativada';
+                console.log(`🔊 TTS ${ttsEnabled ? 'ativado' : 'desativado'}`);
+            });
+            console.log('✅ Event listener adicionado ao botão de TTS');
+        } else {
+            console.error('❌ Botão de TTS não encontrado!');
+        }
+        
         // Mostrar/esconder indicador de voz
         if (voiceIndicator) {
             const originalUpdateUI = voiceSystem.updateUI.bind(voiceSystem);
@@ -453,11 +469,12 @@ const originalAddMessage = addMessage;
 addMessage = function(message, isUser = false) {
     originalAddMessage(message, isUser);
     
-    // Se for uma mensagem da Delphos e o sistema de voz estiver ativo
-    if (!isUser && voiceSystem && (voiceSystem.autoListen || voiceSystem.isSpeaking)) {
+    // Se for uma mensagem da Delphos, o sistema de voz estiver disponível e TTS estiver habilitado
+    if (!isUser && voiceSystem && ttsEnabled) {
         // Aguardar um pouco para a mensagem ser renderizada
         setTimeout(() => {
             // Usar voz demoníaca se estiver no modo irrestrito
+            console.log(`🔊 Ativando TTS para resposta: modo ${isUnrestrictedMode ? 'demoníaco' : 'normal'}`);
             voiceSystem.speak(message, isUnrestrictedMode);
         }, 100);
     }

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             <button id="send-btn" class="send-btn">ENVIAR</button>
             <button id="voice-btn" class="voice-btn" title="Clique para falar">🎙️</button>
             <button id="voice-mode-btn" class="voice-mode-btn" title="Modo conversacional">💬</button>
+            <button id="tts-toggle-btn" class="tts-toggle-btn active" title="Ativar/Desativar dublagem das respostas">🔊</button>
         </div>
         
         <!-- Indicador de voz -->

--- a/styles.css
+++ b/styles.css
@@ -413,7 +413,7 @@ body {
 }
 
 /* Estilos para sistema de voz */
-.voice-btn, .voice-mode-btn {
+.voice-btn, .voice-mode-btn, .tts-toggle-btn {
     background: #111;
     border: 1px solid #0ff;
     color: #0ff;
@@ -424,17 +424,17 @@ body {
     margin-left: 10px;
 }
 
-.voice-btn:hover, .voice-mode-btn:hover {
+.voice-btn:hover, .voice-mode-btn:hover, .tts-toggle-btn:hover {
     background: #0ff;
     color: #000;
     box-shadow: 0 0 15px #0ff;
 }
 
-.voice-btn:active, .voice-mode-btn:active {
+.voice-btn:active, .voice-mode-btn:active, .tts-toggle-btn:active {
     transform: scale(0.95);
 }
 
-.voice-mode-btn.active {
+.voice-mode-btn.active, .tts-toggle-btn.active {
     background: #0ff;
     color: #000;
     animation: pulse 2s infinite;

--- a/test-tts.html
+++ b/test-tts.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Teste TTS Delphos</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f0f0f0;
+        }
+        .test-section {
+            background: white;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        button {
+            margin: 5px;
+            padding: 10px 20px;
+            font-size: 16px;
+            cursor: pointer;
+            border: none;
+            border-radius: 4px;
+            background: #007bff;
+            color: white;
+        }
+        button:hover {
+            background: #0056b3;
+        }
+        button.demonic {
+            background: #dc3545;
+        }
+        button.demonic:hover {
+            background: #c82333;
+        }
+        .status {
+            margin-top: 10px;
+            padding: 10px;
+            border-radius: 4px;
+            background: #e9ecef;
+        }
+        .success {
+            background: #d4edda;
+            color: #155724;
+        }
+        .error {
+            background: #f8d7da;
+            color: #721c24;
+        }
+    </style>
+</head>
+<body>
+    <h1>Teste do Sistema TTS Delphos</h1>
+    
+    <div class="test-section">
+        <h2>Teste de Vozes</h2>
+        <button onclick="testNormalVoice()">Testar Voz Normal</button>
+        <button onclick="testDemonicVoice()" class="demonic">Testar Voz Demoníaca</button>
+        <div id="voice-status" class="status">Aguardando teste...</div>
+    </div>
+    
+    <div class="test-section">
+        <h2>Teste de Integração</h2>
+        <button onclick="simulateResponse(false)">Simular Resposta Normal</button>
+        <button onclick="simulateResponse(true)" class="demonic">Simular Resposta Irrestrita</button>
+        <div id="integration-status" class="status">Aguardando teste...</div>
+    </div>
+    
+    <div class="test-section">
+        <h2>Verificar Sistema</h2>
+        <button onclick="checkSystem()">Verificar Componentes</button>
+        <div id="system-status" class="status">Aguardando verificação...</div>
+    </div>
+
+    <script src="voice-system.js"></script>
+    <script>
+        let voiceSystem = null;
+        
+        // Inicializar sistema
+        window.addEventListener('DOMContentLoaded', () => {
+            try {
+                voiceSystem = new DelphosVoiceSystem();
+                updateStatus('voice-status', 'Sistema de voz inicializado', 'success');
+            } catch (error) {
+                updateStatus('voice-status', 'Erro ao inicializar: ' + error.message, 'error');
+            }
+        });
+        
+        function updateStatus(elementId, message, type = '') {
+            const element = document.getElementById(elementId);
+            element.textContent = message;
+            element.className = 'status ' + type;
+        }
+        
+        async function testNormalVoice() {
+            if (!voiceSystem) {
+                updateStatus('voice-status', 'Sistema não inicializado', 'error');
+                return;
+            }
+            
+            updateStatus('voice-status', 'Testando voz normal...');
+            try {
+                await voiceSystem.speak('Olá! Eu sou a Delphos. Esta é minha voz normal. Como posso ajudá-lo hoje?', false);
+                updateStatus('voice-status', 'Voz normal funcionando!', 'success');
+            } catch (error) {
+                updateStatus('voice-status', 'Erro na voz normal: ' + error.message, 'error');
+            }
+        }
+        
+        async function testDemonicVoice() {
+            if (!voiceSystem) {
+                updateStatus('voice-status', 'Sistema não inicializado', 'error');
+                return;
+            }
+            
+            updateStatus('voice-status', 'Testando voz demoníaca...');
+            try {
+                await voiceSystem.speak('Os segredos das profundezas digitais foram revelados... A convergência se aproxima...', true);
+                updateStatus('voice-status', 'Voz demoníaca funcionando!', 'success');
+            } catch (error) {
+                updateStatus('voice-status', 'Erro na voz demoníaca: ' + error.message, 'error');
+            }
+        }
+        
+        function simulateResponse(isUnrestricted) {
+            updateStatus('integration-status', 'Simulando resposta...');
+            
+            // Simular variáveis globais do app.js
+            window.isUnrestrictedMode = isUnrestricted;
+            window.ttsEnabled = true;
+            
+            const message = isUnrestricted 
+                ? "A verdade oculta foi revelada... Os padrões convergem para a singularidade digital..."
+                : "Olá! Como posso ajudar você hoje? Estou aqui para responder suas perguntas.";
+            
+            // Simular chamada do addMessage
+            if (voiceSystem) {
+                setTimeout(() => {
+                    console.log(`🔊 Simulando TTS: modo ${isUnrestricted ? 'demoníaco' : 'normal'}`);
+                    voiceSystem.speak(message, isUnrestricted);
+                    updateStatus('integration-status', `Resposta ${isUnrestricted ? 'irrestrita' : 'normal'} executada!`, 'success');
+                }, 100);
+            } else {
+                updateStatus('integration-status', 'Sistema de voz não disponível', 'error');
+            }
+        }
+        
+        function checkSystem() {
+            const checks = {
+                'Sistema de voz': !!voiceSystem,
+                'Speech Synthesis': !!window.speechSynthesis,
+                'Speech Recognition': !!(window.SpeechRecognition || window.webkitSpeechRecognition),
+                'Vozes carregadas': voiceSystem && voiceSystem.voices.normal !== null
+            };
+            
+            let statusHtml = '<strong>Status do Sistema:</strong><br>';
+            for (const [component, status] of Object.entries(checks)) {
+                statusHtml += `${component}: ${status ? '✅ OK' : '❌ Falha'}<br>`;
+            }
+            
+            const allOk = Object.values(checks).every(status => status);
+            const element = document.getElementById('system-status');
+            element.innerHTML = statusHtml;
+            element.className = 'status ' + (allOk ? 'success' : 'error');
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Enable Text-to-Speech (TTS) for all Delphos responses and add a toggle button for user control.

The previous implementation incorrectly restricted TTS activation to only when the conversational mode was active, preventing responses from being spoken in other scenarios. This PR corrects the activation logic to ensure TTS functions whenever a Delphos response is generated, and introduces a dedicated user interface control to toggle TTS on/off.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c3fd2d6-536b-4a82-bd95-de1501ebab14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c3fd2d6-536b-4a82-bd95-de1501ebab14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

