### PR TITLE
Corrigir deploy com placeholders e secrets

### DIFF
--- a/.github/workflows/inject-secrets.yml
+++ b/.github/workflows/inject-secrets.yml
@@ -18,13 +18,37 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
       run: |
+        # Criar arquivo temporário para evitar problemas com caracteres especiais
+        cp secrets-config.js secrets-config.js.bak
+        
+        # Substituir os placeholders usando uma abordagem mais robusta
+        # Escapa caracteres especiais nas variáveis de ambiente
+        ESCAPED_OPENAI_KEY=$(printf '%s\n' "$OPENAI_API_KEY" | sed 's/[[\.*^$()+?{|]/\\&/g')
+        ESCAPED_ELEVENLABS_KEY=$(printf '%s\n' "$ELEVENLABS_API_KEY" | sed 's/[[\.*^$()+?{|]/\\&/g')
+        
         # Substituir os placeholders no arquivo de configuração
-        sed -i "s/{{OPENAI_API_KEY}}/$OPENAI_API_KEY/g" secrets-config.js
-        sed -i "s/{{ELEVENLABS_API_KEY}}/$ELEVENLABS_API_KEY/g" secrets-config.js
+        sed "s/'{{OPENAI_API_KEY}}'/'$ESCAPED_OPENAI_KEY'/g" secrets-config.js.bak > secrets-config.js.tmp
+        sed "s/'{{ELEVENLABS_API_KEY}}'/'$ESCAPED_ELEVENLABS_KEY'/g" secrets-config.js.tmp > secrets-config.js
+        
+        # Limpar arquivos temporários
+        rm -f secrets-config.js.bak secrets-config.js.tmp
         
         # Verificar se a substituição foi feita corretamente
         if grep -q "{{" secrets-config.js; then
           echo "Erro: Placeholders não foram substituídos completamente"
+          echo "Conteúdo do arquivo após substituição:"
+          cat secrets-config.js
+          exit 1
+        fi
+        
+        # Verificar se as variáveis de ambiente estão definidas
+        if [ -z "$OPENAI_API_KEY" ]; then
+          echo "Erro: OPENAI_API_KEY não está definida"
+          exit 1
+        fi
+        
+        if [ -z "$ELEVENLABS_API_KEY" ]; then
+          echo "Erro: ELEVENLABS_API_KEY não está definida"
           exit 1
         fi
         

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Dependencies
+node_modules/
+package-lock.json
+yarn.lock
+
+# Environment variables
+.env
+.env.local
+.env.production
+.env.*.local
+
+# Secrets - NUNCA commitar arquivos com secrets reais
+secrets-config.js.bak
+secrets-config.js.tmp
+*-with-secrets.js
+*.secrets.js
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build
+dist/
+build/
+.cache/
+
+# Temporary files
+*.tmp
+*.temp

--- a/CONFIGURAR-SECRETS.md
+++ b/CONFIGURAR-SECRETS.md
@@ -1,0 +1,65 @@
+# Configuração de Secrets no GitHub
+
+Este documento explica como configurar os secrets necessários para o deploy automático do projeto.
+
+## Secrets Necessários
+
+O projeto requer os seguintes secrets:
+
+1. **OPENAI_API_KEY** - Chave de API da OpenAI
+2. **ELEVENLABS_API_KEY** - Chave de API do Eleven Labs
+
+## Como Configurar os Secrets
+
+1. Acesse as configurações do seu repositório no GitHub
+2. No menu lateral, clique em **Secrets and variables** > **Actions**
+3. Clique em **New repository secret**
+4. Adicione cada secret:
+   - Nome: `OPENAI_API_KEY`
+   - Valor: Sua chave de API da OpenAI
+   
+   - Nome: `ELEVENLABS_API_KEY`
+   - Valor: Sua chave de API do Eleven Labs
+
+## Verificando a Configuração
+
+Após configurar os secrets:
+
+1. Faça um commit e push para a branch `main` ou `master`
+2. Acesse a aba **Actions** do repositório
+3. Verifique se o workflow "Deploy with Secrets" foi executado com sucesso
+
+## Desenvolvimento Local
+
+Durante o desenvolvimento local, as chaves de API são obtidas do localStorage. Para configurá-las:
+
+```javascript
+// No console do navegador:
+localStorage.setItem('openai_api_key', 'sua-chave-aqui');
+localStorage.setItem('elevenlabs_api_key', 'sua-chave-aqui');
+```
+
+## Segurança
+
+- **NUNCA** commite chaves de API reais no código
+- Os secrets são injetados automaticamente durante o deploy
+- O arquivo `secrets-config.js` sempre deve conter apenas placeholders no repositório
+- Use o `.gitignore` para evitar commits acidentais de arquivos com secrets
+
+## Troubleshooting
+
+### Erro: "Placeholders não foram substituídos completamente"
+
+Este erro indica que os secrets não foram configurados corretamente no GitHub. Verifique:
+
+1. Se os nomes dos secrets estão corretos (OPENAI_API_KEY e ELEVENLABS_API_KEY)
+2. Se os valores não estão vazios
+3. Se não há caracteres especiais problemáticos nos valores
+
+### Erro: "OPENAI_API_KEY não está definida"
+
+Este erro indica que o secret OPENAI_API_KEY não foi configurado no repositório.
+
+### Erro: "ELEVENLABS_API_KEY não está definida"
+
+Este erro indica que o secret ELEVENLABS_API_KEY não foi configurado no repositório.


### PR DESCRIPTION
Fix GitHub Actions workflow to correctly inject secrets, add `.gitignore`, and provide documentation for secret configuration.

The previous `sed` command in the GitHub Actions workflow failed to correctly replace placeholders in `secrets-config.js` when values contained single quotes or special characters, leading to an incomplete substitution error during deployment. This PR enhances the `sed` script with better escaping and adds checks to ensure proper secret injection.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fc165d3-d169-4a54-8073-21c69fcc9ae1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fc165d3-d169-4a54-8073-21c69fcc9ae1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

