### PR TITLE
Push gh-pages branch with correct permissions

### DIFF
--- a/.github/workflows/inject-secrets.yml
+++ b/.github/workflows/inject-secrets.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -79,7 +84,7 @@ jobs:
         head -15 secrets-config.js
     
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./


### PR DESCRIPTION
Add explicit GitHub Actions permissions and update `actions-gh-pages` to v4 to resolve 403 permission errors during deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-1318abe5-5b06-461e-a839-801de366fdc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1318abe5-5b06-461e-a839-801de366fdc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

