### PR TITLE
Fix Vapi SDK loading error in conversation simulator

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,24 +44,51 @@
     </main>
 
     <script type="module">
-      // Carrega o SDK da Vapi com fallback: ESM primeiro, depois UMD global
+      // Carrega o SDK da Vapi priorizando UMD (mais compatível), com fallbacks
       let VapiCtor = null;
       async function loadVapi() {
         if (VapiCtor) return VapiCtor;
-        try {
-          const mod = await import('https://cdn.jsdelivr.net/npm/@vapi-ai/web/+esm');
-          VapiCtor = mod?.default ?? mod?.Vapi ?? mod;
-        } catch (e) {
-          await new Promise((resolve, reject) => {
-            const s = document.createElement('script');
-            s.src = 'https://cdn.jsdelivr.net/npm/@vapi-ai/web';
-            s.onload = resolve;
-            s.onerror = reject;
-            document.head.appendChild(s);
-          });
-          VapiCtor = window.Vapi;
+        // 1) Tenta UMD por diferentes CDNs
+        const umdUrls = [
+          'https://cdn.jsdelivr.net/npm/@vapi-ai/web/dist/index.umd.js',
+          'https://cdn.jsdelivr.net/npm/@vapi-ai/web',
+          'https://unpkg.com/@vapi-ai/web@latest/dist/index.umd.js'
+        ];
+        for (const url of umdUrls) {
+          try {
+            await new Promise((resolve, reject) => {
+              const s = document.createElement('script');
+              s.src = url;
+              s.async = true;
+              s.defer = true;
+              s.onload = resolve;
+              s.onerror = reject;
+              document.head.appendChild(s);
+            });
+            const candidate = (window.Vapi && (window.Vapi.default || window.Vapi)) || window.VapiWeb || window.VapiAI || window.vapi;
+            if (typeof candidate === 'function') {
+              VapiCtor = candidate;
+              return VapiCtor;
+            }
+          } catch {}
         }
-        return VapiCtor;
+        // 2) Fallback ESM
+        const esmUrls = [
+          'https://cdn.jsdelivr.net/npm/@vapi-ai/web/+esm',
+          'https://esm.sh/@vapi-ai/web',
+          'https://cdn.skypack.dev/@vapi-ai/web'
+        ];
+        for (const url of esmUrls) {
+          try {
+            const mod = await import(url);
+            const candidate = mod?.default ?? mod?.Vapi ?? mod?.VapiWeb ?? mod;
+            if (typeof candidate === 'function') {
+              VapiCtor = candidate;
+              return VapiCtor;
+            }
+          } catch {}
+        }
+        throw new Error('Não foi possível carregar o SDK da Vapi a partir das CDNs conhecidas.');
       }
 
       const NORMAL_ASSISTANT_ID = 'b7146a9e-bae1-4245-87f7-e72b1335ac55';


### PR DESCRIPTION
Refactor Vapi SDK loader in `public/index.html` to fix loading failures by improving CDN fallbacks and global constructor detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac83d9a4-34ee-4caf-b01a-f192a298e8f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac83d9a4-34ee-4caf-b01a-f192a298e8f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

